### PR TITLE
Remove references to Eli's GH username

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @elichad @joelvdavies @leandro-liborio @patrick-austin
+* @joelvdavies @leandro-liborio @patrick-austin

--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@elichad](https://github.com/elichad/)
 * [@joelvdavies](https://github.com/joelvdavies/)
 * [@leandro-liborio](https://github.com/leandro-liborio/)
 * [@patrick-austin](https://github.com/patrick-austin/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,4 +75,3 @@ extra:
     - joelvdavies
     - patrick-austin
     - leandro-liborio
-    - elichad


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Just searched for and deleted any references to Eli's username. It's still automatically requesting a review, and I can't see a way of disabling that manually - hopefully once this is merged it'll stop being a bother?

EDIT: can remove the request once the PR is created but I suspect by that point damage is done.